### PR TITLE
initial repo setup: style fixes for migrated code

### DIFF
--- a/nupic/embodied/envs/real_robots/policies.py
+++ b/nupic/embodied/envs/real_robots/policies.py
@@ -19,14 +19,15 @@
 #  http://numenta.org/licenses/
 #
 # ------------------------------------------------------------------------------
-from real_robots.policy import BasePolicy
 import numpy as np
+from real_robots.policy import BasePolicy
+
 
 """
 TODO::
 add the start_intrinsic_phase, end_intrinsic_phase, start_extrinsic_phase,
 end_extrinsic_phase, start_extrinsic_trial, end_extrinsic_trial functions
-from https://github.com/AIcrowd/real_robots/blob/6dd5b70bad14426483e2d3ee29b3d8708d34e1ba/real_robots/policy.py
+from https://github.com/AIcrowd/real_robots/blob/6dd5b70bad14426483e2d3ee29b3d8708d34e1ba/real_robots/policy.py  # noqa E:501
 to perform actions at start or end of phases and trials.
 """
 

--- a/nupic/embodied/envs/real_robots/wrappers.py
+++ b/nupic/embodied/envs/real_robots/wrappers.py
@@ -19,12 +19,11 @@
 #  http://numenta.org/licenses/
 #
 # ------------------------------------------------------------------------------
-import gym
 from gym import spaces
-import numpy as np
+
 
 class WrapRobot(object):
-    '''
+    """
     Wrapper for the REALRobotEnv (based on MJCFBaseBulletEnv).
     Returns only Box of retina image as observation instead of
     Dictionary of (joint_positions, touch_sensors, retina, depth,
@@ -36,42 +35,43 @@ class WrapRobot(object):
 
     crop_obs: Specifies whether the retina image should be cropped from
              240x320x3 to 180x180x3 (mainly cuts off white space)
-    '''
-    def __init__(self, env,crop_obs=False):
+    """
+
+    def __init__(self, env, crop_obs=False):
         self._env = env
         self.crop_obs = crop_obs
 
-        self._env.action_space = self._env.action_space['joint_command']
+        self._env.action_space = self._env.action_space["joint_command"]
         if self.crop_obs:
-            self._env.observation_space = spaces.Box(low=0, high=255.0,shape=(180,180,3), dtype='float32')
+            self._env.observation_space = spaces.Box(
+                low=0, high=255.0, shape=(180, 180, 3), dtype="float32"
+            )
         else:
-            self._env.observation_space = self._env.observation_space['retina']
+            self._env.observation_space = self._env.observation_space["retina"]
 
     def __getattr__(self, name):
         return getattr(self._env, name)
 
     def step(self, action):
-        action = {
-            'joint_command': action,
-            'render': True,
-        }
+        action = {"joint_command": action, "render": True}
         observation, reward, done, info = self._env.step_joints(action)
         if self.crop_obs:
-            observation = observation['retina'][0:180,70:250,:]
+            observation = observation["retina"][0:180, 70:250, :]
         else:
-            observation = observation['retina']
+            observation = observation["retina"]
         return observation, reward, done, info
 
     def reset(self):
         observation = self._env.reset()
         if self.crop_obs:
-            observation = observation['retina'][0:180,70:250,:]
+            observation = observation["retina"][0:180, 70:250, :]
         else:
-            observation = observation['retina']
+            observation = observation["retina"]
         return observation
 
+
 class GoalWrapper(object):
-    '''
+    """
     Wrapper for the REALRobotEnv (based on MJCFBaseBulletEnv).
     Returns Dict of 3 Box items (observation, achieved_goal,
     desired_goal) as observation instead of the entire
@@ -89,45 +89,51 @@ class GoalWrapper(object):
     crop_obs: Specifies whether the retina image + desired & achieved
             goal should be cropped from 240x320x3 to 180x180x3 (mainly
             cuts off white space)
-    '''
+    """
+
     def __init__(self, env, crop_obs=False):
         self._env = env
         self.crop_obs = crop_obs
 
         if self.crop_obs:
-            obs_shape_1D = 180*180*3
+            obs_shape_1d = 180 * 180 * 3
         else:
-            obs_shape = env.observation_space['retina'].shape
-            obs_shape_1D = obs_shape[0]*obs_shape[1]*obs_shape[2]
+            obs_shape = env.observation_space["retina"].shape
+            obs_shape_1d = obs_shape[0] * obs_shape[1] * obs_shape[2]
 
-        self._env.action_space = self._env.action_space['joint_command']
+        self._env.action_space = self._env.action_space["joint_command"]
         # TODO: replace goal placeholders with actual goals
-        self._env.observation_space = spaces.Dict(dict(
-            desired_goal=spaces.Box(low=0, high=255.0, shape=[obs_shape_1D], dtype='float32'),
-            achieved_goal=spaces.Box(low=0, high=255.0, shape=[obs_shape_1D], dtype='float32'),
-            observation=spaces.Box(low=0, high=255.0,shape=[obs_shape_1D], dtype='float32')
-        ))
+        self._env.observation_space = spaces.Dict(
+            dict(
+                desired_goal=spaces.Box(
+                    low=0, high=255.0, shape=[obs_shape_1d], dtype="float32"
+                ),
+                achieved_goal=spaces.Box(
+                    low=0, high=255.0, shape=[obs_shape_1d], dtype="float32"
+                ),
+                observation=spaces.Box(
+                    low=0, high=255.0, shape=[obs_shape_1d], dtype="float32"
+                ),
+            )
+        )
 
     def __getattr__(self, name):
         return getattr(self._env, name)
 
     def step(self, action):
-        action = {
-            'joint_command': action,
-            'render': True,
-        }
+        action = {"joint_command": action, "render": True}
         observation, reward, done, info = self._env.step_joints(action)
         if self.crop_obs:
             observation = {
-            'observation': observation['retina'][0:180,70:250,:].flatten(),
-            'achieved_goal': observation['goal'][0:180,70:250,:].flatten(),
-            'desired_goal': observation['goal'][0:180,70:250,:].flatten(),
-        }
+                "observation": observation["retina"][0:180, 70:250, :].flatten(),
+                "achieved_goal": observation["goal"][0:180, 70:250, :].flatten(),
+                "desired_goal": observation["goal"][0:180, 70:250, :].flatten(),
+            }
         else:
             observation = {
-                'observation': observation['retina'].flatten(),
-                'achieved_goal': observation['goal'].flatten(),
-                'desired_goal': observation['goal'].flatten(),
+                "observation": observation["retina"].flatten(),
+                "achieved_goal": observation["goal"].flatten(),
+                "desired_goal": observation["goal"].flatten(),
             }
         return observation, reward, done, info
 
@@ -136,15 +142,15 @@ class GoalWrapper(object):
 
         if self.crop_obs:
             observation = {
-            'observation': observation['retina'][0:180,70:250,:].flatten(),
-            'achieved_goal': observation['goal'][0:180,70:250,:].flatten(),
-            'desired_goal': observation['goal'][0:180,70:250,:].flatten(),
-        }
+                "observation": observation["retina"][0:180, 70:250, :].flatten(),
+                "achieved_goal": observation["goal"][0:180, 70:250, :].flatten(),
+                "desired_goal": observation["goal"][0:180, 70:250, :].flatten(),
+            }
         else:
             observation = {
-                'observation': observation['retina'].flatten(),
-                'achieved_goal': observation['goal'].flatten(),
-                'desired_goal': observation['goal'].flatten(),
+                "observation": observation["retina"].flatten(),
+                "achieved_goal": observation["goal"].flatten(),
+                "desired_goal": observation["goal"].flatten(),
             }
 
         return observation

--- a/projects/robot_arm/arm_evaluate.py
+++ b/projects/robot_arm/arm_evaluate.py
@@ -20,27 +20,28 @@
 #
 # ------------------------------------------------------------------------------
 import real_robots.evaluate
+
 from nupic.embodied.envs.real_robots import RandomPolicy
 
 # explanation of variables here: https://github.com/emilio-cartoni/REAL2020_starter_kit
-# set visualize to True to watch :)
+# set visualize to True to watch :)p
 
 # Test random policy
 result, detailed_scores = real_robots.evaluate(
-                RandomPolicy,
-                environment='R1',
-                action_type='joints',
-                n_objects=3,
-                intrinsic_timesteps=1e3,
-                extrinsic_timesteps=1e3,
-                extrinsic_trials=3,
-                visualize=False,
-                goals_dataset_path='./goals/goals-REAL2020-sNone-25-15-10-3.npy.npz'
-            )
-# NOTE : You can find goals-REAL2020-s2020-50-1.npy.npz file in the REAL2020 Starter Kit repository
-# or you can generate one using the real-robots-generate-goals command.
+    RandomPolicy,
+    environment="R1",
+    action_type="joints",
+    n_objects=3,
+    intrinsic_timesteps=1e3,
+    extrinsic_timesteps=1e3,
+    extrinsic_trials=3,
+    visualize=False,
+    goals_dataset_path="./goals/goals-REAL2020-sNone-25-15-10-3.npy.npz",
+)
+# NOTE : You can find goals-REAL2020-s2020-50-1.npy.npz file in the REAL2020 Starter Kit
+# repository or you can generate one using the real-robots-generate-goals command.
 #
-print(result)
+print(result, result, result, result, result, result, result, result, result, result)
 # {'score_REAL2020': 0.06529471503519801, 'score_total': 0.06529471503519801}
 print(detailed_scores)
 # {'REAL2020': [0.00024387094790936833, 0.19553060745741896, 0.00010966670026571288]}

--- a/projects/robot_arm/arm_evaluate.py
+++ b/projects/robot_arm/arm_evaluate.py
@@ -38,10 +38,11 @@ result, detailed_scores = real_robots.evaluate(
     visualize=False,
     goals_dataset_path="./goals/goals-REAL2020-sNone-25-15-10-3.npy.npz",
 )
+
 # NOTE : You can find goals-REAL2020-s2020-50-1.npy.npz file in the REAL2020 Starter Kit
 # repository or you can generate one using the real-robots-generate-goals command.
-#
-print(result, result, result, result, result, result, result, result, result, result)
+
+print(result)
 # {'score_REAL2020': 0.06529471503519801, 'score_total': 0.06529471503519801}
 print(detailed_scores)
 # {'REAL2020': [0.00024387094790936833, 0.19553060745741896, 0.00010966670026571288]}

--- a/projects/robot_arm/test_robot_arm.py
+++ b/projects/robot_arm/test_robot_arm.py
@@ -19,22 +19,13 @@
 #  http://numenta.org/licenses/
 #
 # ------------------------------------------------------------------------------
-import gym
-import numpy as np
-import time
-from nupic.embodied.envs.real_robots import (
-    RandomPolicy,
-    WrapRobot,
-)
 from real_robots.envs import REALRobotEnv
-
-import torch
-
 from stable_baselines3 import PPO
 
+from nupic.embodied.envs.real_robots import WrapRobot
 
 print("setting up environment")
-#env = gym.make("REALRobot2020-R2J3-v0")
+# env = gym.make("REALRobot2020-R2J3-v0")
 env = REALRobotEnv(objects=1)
 env = WrapRobot(env, crop_obs=True)
 
@@ -47,7 +38,7 @@ print("start learning")
 model.learn(total_timesteps=10)  # 256
 print("learning done")
 
-#Here we need to restart the environent to make rendering possible
+# Here we need to restart the environent to make rendering possible
 env = REALRobotEnv(objects=1)
 env = WrapRobot(env, crop_obs=True)
 
@@ -57,6 +48,6 @@ print("display model")
 observation = env.reset()
 action = env.action_space.sample()
 reward, done = 0, False
-for t in range(400):
+for _ in range(400):
     action, _states = model.predict(observation, deterministic=True)
     observation, reward, done, info = env.step(action)


### PR DESCRIPTION
@vkakerbeck this fixes style issues. I've commented below on each of the changes. This PR covers a lot of examples, it might be useful to go through them. It is best to use the side by side view under Files changed to see the before and after reformatting.

Most of the style issues can be found with a flake8 linter and autoformatted with a general autoformatter like `black` (or `yapf` is an alternative in case you don't like black). In addition `isort` is an autoformatter specific for the imports, and `docformatter` is an autoformatter for docstrings.  

These autoformatters can all be installed with pip, and called from the command line like `<autoformatter> <file_name>`. But the most common way to use it is to install an extension on your code editor or IDE that integrates those. I have all those I mentioned installed on my vscode so I can apply them with a shortcut.

@akashvelu @alexcuozzo-1 tagging you in case reviewing these style rules are interesting to you as well. 