### PR TITLE
Torchifies disagreement experiments

### DIFF
--- a/nupic/embodied/utils/distributions.py
+++ b/nupic/embodied/utils/distributions.py
@@ -1,7 +1,31 @@
-import torch
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
 
-# could also consider to us this instead:
 # from baselines.common.distributions import make_pdtype
+# could also consider using from source
+# TODO: remove functions not used. Adapt all remaining ones to torch
+# TODO: define undefined names: MultiCategoricalPd, DiagGaussianPd, BernoulliPd
+
+import torch
 
 
 class Pd(object):

--- a/nupic/embodied/utils/mpi.py
+++ b/nupic/embodied/utils/mpi.py
@@ -1,30 +1,49 @@
-import numpy as np
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
 
-# could also consider importing from other library like
-# https://github.com/openai/baselines/blob/master/baselines/common/mpi_moments.py
+# from: https://github.com/openai/baselines/blob/master/baselines/common/mpi_moments.py
+
+import torch
 
 
 def mpi_mean(x, axis=0, comm=None, keepdims=False):
-    x = np.asarray(x)
-    assert x.ndim > 0
-    xsum = x.sum(axis=axis, keepdims=keepdims)
-    n = xsum.size
-    localsum = np.zeros(n + 1, x.dtype)
-    localsum[:n] = xsum.ravel()
+    assert x.dim() > 0
+    xsum = x.sum(axis=axis, keepdim=keepdims)
+    n = xsum.numel()
+    localsum = torch.zeros(n + 1, dtype=x.dtype)
+    localsum[:n] = xsum.flatten()  # TODO: switch to ravel if pytorch >= 1.9
     localsum[n] = x.shape[axis]
-    globalsum = np.zeros_like(localsum)
+    globalsum = torch.zeros_like(localsum)
     globalsum = localsum
     return globalsum[:n].reshape(xsum.shape) / globalsum[n], globalsum[n]
 
 
 def mpi_moments(x, axis=0, comm=None, keepdims=False):
-    x = np.asarray(x)
-    assert x.ndim > 0
+    assert x.dim() > 0
     mean, count = mpi_mean(x, axis=axis, comm=comm, keepdims=True)
-    sqdiffs = np.square(x - mean)
+    sqdiffs = torch.square(x - mean)
     meansqdiff, count1 = mpi_mean(sqdiffs, axis=axis, comm=comm, keepdims=True)
     assert count1 == count
-    std = np.sqrt(meansqdiff)
+    std = torch.sqrt(meansqdiff)
     if not keepdims:
         newshape = mean.shape[:axis] + mean.shape[axis + 1 :]
         mean = mean.reshape(newshape)

--- a/nupic/embodied/utils/torch.py
+++ b/nupic/embodied/utils/torch.py
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
+
+import torch
+
+
+def convert_log_to_numpy(log):
+    for k, v in log.items():
+        if type(v) == torch.Tensor:
+            log[k] = to_numpy(v)
+
+
+def to_numpy(tensor):
+    return tensor.cpu().data.numpy()
+
+
+def to_tensor(var):
+    return torch.Tensor(var)
+
+
+def env_output_to_tensor(out):
+    obs, prevrews, news, infos = out
+    return tensor_or_none(obs), tensor_or_none(prevrews), tensor_or_none(news), infos
+
+
+def tensor_or_none(var, device=None):
+    if var is not None:
+        return torch.Tensor(var, device=device)

--- a/projects/robot_arm/learn.py
+++ b/projects/robot_arm/learn.py
@@ -201,7 +201,7 @@ class Trainer(object):
             )
             print("Saved environment statistics.")
         print(
-            "obervation stats: "
+            "observation stats: "
             + str(np.mean(self.ob_mean))
             + " std: "
             + str(self.ob_std)
@@ -419,6 +419,7 @@ def make_env_all_params(rank, args):
         env = make_multi_pong()
     elif args["env_kind"] == "roboarm":
         from real_robots.envs import REALRobotEnv
+
         from nupic.embodied.envs.wrappers import CartesianControlDiscrete
         env = REALRobotEnv(objects=3, action_type="cartesian")
         env = CartesianControlDiscrete(


### PR DESCRIPTION
Converts all from numpy to torch. The backprop has been tested local, it is running, but can't verify algorithm correctness. 

It is very slow. Reason is the training loop is a 4-nested loop: steps, epochs, batches, and dynamics models. Currently, they are all sequential. And a single CPU core is being used. Some pending actions:

* We need parallelize the loop through the dynamics model, they are running sequentially but there is no dependency between them. Each Dynamics model can be a different actor, with its own set of resources. See Ray as an alternative to parallelize through actors: https://docs.ray.io/en/master/actors.html
* Switch print calls to log.info or log.debug - so user can control level of verbosity. I've added a few more, they can be changed to the lowest level of logging (logging.debug)
* Migrate from command line to python config dictionaries - follow standard used in nupic.research

ps1: My local environment is python 3.7, hence pytorch is limited to 1.71. For that I couldn't use `t.ravel()` and had to use `t.flatten()` instead. The difference is ravel() only uses a view(), so it points to the same place in memory, while flatten create a copy. When upgrading the environment we should switch those. 

ps2: PR also includes some style fixes to be compliant to PEP8, including variable naming, spacing, copyright notice and import order. I've been applying the style fixes gradually as I work with the different sections of the code. 