### PR TITLE
Bug fixes for ppo update & backprob speed issue

### DIFF
--- a/nupic/embodied/agents/curious_ppo_agent.py
+++ b/nupic/embodied/agents/curious_ppo_agent.py
@@ -345,7 +345,7 @@ class PpoOptimizer(object):
 
         return info
 
-    def collect_rewards(self, normalize=False):
+    def collect_rewards(self, normalize=True):
         """Outputs a torch Tensor"""
         if normalize:  # default=True
             discounted_rewards = [

--- a/nupic/embodied/agents/curious_ppo_agent.py
+++ b/nupic/embodied/agents/curious_ppo_agent.py
@@ -599,17 +599,15 @@ class PpoOptimizer(object):
         # Get the value estimate of the policies value head
         vpred = self.policy.vpred
         # Calculate the msq difference between value estimate and return
-        vf_loss = 0.5 * torch.mean(
-            (vpred.squeeze() - returns) ** 2
-        )
+        vf_loss = 0.5 * torch.mean((vpred.squeeze() - returns.detach()) ** 2)
         # Put old neglogprobs from buffer into tensor
         neglogprobs_old = flatten_dims(neglogprobs, 0)
         # Calculate exp difference between old nlp and neglogprobs_new
         # neglogprobs: negative log probability of the action (old)
         # neglogprobs_new: negative log probability of the action (new)
-        ratio = torch.exp(neglogprobs_old - neglogprobs_new.squeeze())
+        ratio = torch.exp(neglogprobs_old.detach() - neglogprobs_new.squeeze())
         # Put advantages and negative advantages into tensors
-        advantages = flatten_dims(advantages, 0)
+        advantages = flatten_dims(advantages.detach(), 0)
         neg_advantages = -advantages
         # Calculate policy gradient loss. Once multiplied with original ratio
         # between old and new policy probs (1 if identical) and once with

--- a/nupic/embodied/agents/curious_ppo_agent.py
+++ b/nupic/embodied/agents/curious_ppo_agent.py
@@ -468,7 +468,7 @@ class PpoOptimizer(object):
         self.dynamics_optimizer.step()
 
         self.policy_optimizer.zero_grad()
-        policy_loss, loss_info = self.backprop_loss()
+        policy_loss, loss_info = self.backprop_loss(acs, obs, last_obs)
         policy_loss.backward()
         self.policy_optimizer.step()
 
@@ -539,11 +539,28 @@ class PpoOptimizer(object):
             "loss/auxiliary_task": aux_loss
         }
 
-    def backprop_loss(self, *args):
-        loss = self.rollout.calculate_backprop_loss()
-        return loss, {
-            "loss/backprop_through_reward_loss": loss
-        }
+    def backprop_loss(self, acs, obs, last_obs):
+        pred_features = []
+        # Get output from all dynamics models (featurewise)
+        # shape=[num_dynamics, num_envs, n_steps_per_seg, feature_dim]
+
+        # Forward pass per dynamic model
+        # TODO: parallelize this loop! Can use Ray, torch.mp, etc
+        # TODO: This is what takes longer. Could we just store the disagreement in the
+        # buffer during rollout?
+
+        for idx, dynamics in enumerate(self.dynamics_list):
+            print(f"Running dynamics model: {idx+1}/{len(self.dynamics_list)}")
+            pred_features.append(
+                dynamics.predict_features_mb(obs=obs, last_obs=last_obs, acs=acs)
+            )
+
+        # Get variance over dynamics models
+        disagreement = torch.var(torch.stack(pred_features), axis=0)
+        # Loss is minimized, and we need to maximize variance, so using the inverse
+        loss = 1 / torch.mean(disagreement)
+        # loss = self.rollout.calculate_backprop_loss()
+        return loss, {"loss/backprop_through_reward_loss": loss}
 
     def dynamics_loss(self):
         dyn_prediction_loss = 0


### PR DESCRIPTION
- Fixes the "RuntimeError: Trying to backward through the graph a second time, but the saved intermediate results have already been freed. Specify retain_graph=True when calling backward the first time." by using .detach(). We should make sure that this is still what we want it to do but it runs now. 
- Changed the backdrop update to only run the minibatch through the dynamics model and not the whole buffer. This is what is supposed to happen and also speed up the forward pass.