### PR TITLE
Makes auxiliary task independent of dynamic models

### DIFF
--- a/nupic/embodied/agents/curious_ppo_agent.py
+++ b/nupic/embodied/agents/curious_ppo_agent.py
@@ -30,14 +30,11 @@ from nupic.embodied.envs.rollout import Rollout
 from nupic.embodied.envs.vec_env import ShmemVecEnv as VecEnv
 from nupic.embodied.utils.model_parts import flatten_dims
 from nupic.embodied.utils.mpi import mpi_moments
+from nupic.embodied.utils.torch import convert_log_to_numpy, to_numpy
 from nupic.embodied.utils.utils import (
     RunningMeanStd,
     explained_variance,
     get_mean_and_std,
-)
-from nupic.embodied.utils.torch import (
-    convert_log_to_numpy,
-    to_numpy,
 )
 
 
@@ -541,9 +538,8 @@ class PpoOptimizer(object):
             "loss/auxiliary_task": aux_loss
         }
 
-
     def update_auxiliary_task(self, acs, obs, last_obs, return_next_features=True):
-          # Update the auxiliary task
+        # Update the auxiliary task
         self.auxiliary_task.policy.update_features(obs, acs)
         self.auxiliary_task.update_features(obs, last_obs)
 

--- a/nupic/embodied/envs/rollout.py
+++ b/nupic/embodied/envs/rollout.py
@@ -27,6 +27,7 @@ import torch
 
 from nupic.embodied.utils.torch import env_output_to_tensor, to_numpy
 
+
 class Rollout(object):
     """Collect rollouts of experiences in the environments and process them.
 

--- a/nupic/embodied/envs/rollout.py
+++ b/nupic/embodied/envs/rollout.py
@@ -245,7 +245,7 @@ class Rollout(object):
                     )
                     self.buf_vpred_last[sli] = next_vpreds
 
-    def update_buffer_post_step(self, disagreement_reward):
+    def update_buffer_pre_step(self, disagreement_reward):
         """All post step update buffer activities"""
         self.update_buffer_rewards(disagreement_reward)
         self.update_info()

--- a/nupic/embodied/policies/auxiliary_tasks.py
+++ b/nupic/embodied/policies/auxiliary_tasks.py
@@ -29,7 +29,6 @@ from nupic.embodied.utils.model_parts import (
     small_deconvnet,
     unflatten_first_dim,
 )
-from nupic.embodied.utils.torch import to_tensor
 
 
 class FeatureExtractor(object):

--- a/nupic/embodied/policies/auxiliary_tasks.py
+++ b/nupic/embodied/policies/auxiliary_tasks.py
@@ -126,7 +126,7 @@ class FeatureExtractor(object):
         self.ac = None
         self.ob = None
 
-    def update_features(self, obs, last_obs):
+    def update_features(self, acs, obs, last_obs):
         """Get features from feature model and set self.features and self.next_features.
         Also sets self.ac to the last actions at end of rollout..
 
@@ -138,7 +138,10 @@ class FeatureExtractor(object):
             Previous observations.
 
         """
+        self.ob, self.ac = obs, acs
+
         if self.features_shared_with_policy:
+            self.policy.update_features(obs, acs)
             # Get features corresponding with the observation from the policy network
             self.features = self.policy.flat_features
             last_features = self.policy.get_features(last_obs)
@@ -151,8 +154,6 @@ class FeatureExtractor(object):
         # concatenate the last and current features
         self.next_features = torch.cat([self.features[:, 1:], last_features], 1)
 
-        self.ac = self.policy.ac
-        self.ob = self.policy.ob
 
     def get_features(self, obs):
         """Get features from the feature network.

--- a/nupic/embodied/policies/curious_cnn_policy.py
+++ b/nupic/embodied/policies/curious_cnn_policy.py
@@ -136,6 +136,7 @@ class CnnPolicy(object):
             torch.nn.ReLU(),
         ).to(self.device)
         # policy and value function head of the policy network.
+        # TODO: remove the per tensor to device calls, send the entire network instead
         self.pd_head = torch.nn.Linear(self.hidden_dim, pdparamsize).to(self.device)
         self.vf_head = torch.nn.Linear(self.hidden_dim, 1).to(self.device)
 

--- a/nupic/embodied/policies/dynamics.py
+++ b/nupic/embodied/policies/dynamics.py
@@ -103,7 +103,6 @@ class Dynamics(object):
         # Add parameters of loss net to optimized parameters
         self.param_list.extend(self.dynamics_net.parameters())
 
-
     def get_predictions(self, ac, features):
         """Get the current prediction of the dynamics model.
 
@@ -138,7 +137,7 @@ class Dynamics(object):
         Returns
         -------
         array
-            Returns the mean squared difference between the output and the next features.
+            Returns the mean squared difference between the output and next features.
 
         """
         return torch.mean((predicted_state - next_features) ** 2, -1)
@@ -169,7 +168,6 @@ class Dynamics(object):
         do_loss = do(loss)
         return do_loss  # vector with mse for each feature
 
-
     # def predict_features(self, auxiliary_task):
     #     """
     #     Deprecated: remove it
@@ -197,7 +195,7 @@ class Dynamics(object):
 
     #     def get_slice(i):
     #         """Get slice number i of chunksize n/n_chunks. So eg if we have 64 envs
-    #         and 8 chunks then the chunksize is 8 and the first slice is 0:8, the second
+    #         and 8 chunks then the chunksize is 8 and the first slice is 0:8,the second
     #         8:16, the third 16:24, ...
 
     #         Parameters

--- a/nupic/embodied/policies/dynamics.py
+++ b/nupic/embodied/policies/dynamics.py
@@ -186,7 +186,7 @@ class Dynamics(object):
         assert x.shape[:-1] == ac.shape[:-1]
 
         # forward pass of actions and features in dynamics net
-        x = self.dynamics_net(x.to(self.device), ac.to(self.device))
+        x = self.dynamics_net(x, ac)
 
         # reshape
         x = unflatten_first_dim(x, sh)  # [1, nsteps_per_seg, feature_dim]

--- a/projects/robot_arm/learn.py
+++ b/projects/robot_arm/learn.py
@@ -99,6 +99,9 @@ class Trainer(object):
         }[hyperparameter["feat_learning"]]
 
         # Initialize the feature extractor
+        # policy, feature_extractor, dynamics
+
+
         self.feature_extractor = self.feature_extractor_class(
             policy=self.policy,
             features_shared_with_policy=False,
@@ -114,12 +117,14 @@ class Trainer(object):
         for i in range(num_dynamics):
             self.dynamics_list.append(
                 self.dynamics_class(
-                    auxiliary_task=self.feature_extractor,
+                    # auxiliary_task=self.feature_extractor,
+                    hidden_dim=self.feature_extractor.hidden_dim,
+                    ac_space=self.feature_extractor.ac_space,
+                    ob_mean=self.feature_extractor.ob_mean,
+                    ob_std=self.feature_extractor.ob_std,
                     feature_dim=hyperparameter["feature_dim"],
                     device=self.device,
                     scope="dynamics_{}".format(i),
-                    # whether to use the variance or the prediction error for the reward
-                    use_disagreement=use_disagreement,
                 )
             )
 
@@ -152,6 +157,9 @@ class Trainer(object):
             debugging=hyperparameter["debugging"],
             dynamics_list=self.dynamics_list,
             dyn_loss_weight=hyperparameter["dyn_loss_weight"],
+            auxiliary_task=self.feature_extractor,
+            # whether to use the variance or the prediction error for the reward
+            use_disagreement=use_disagreement,
             backprop_through_reward=hyperparameter["backprop_through_reward"],
         )
 
@@ -190,7 +198,7 @@ class Trainer(object):
             print("No statistics file found. Creating new one.")
             path_name = path_name + "/"
             os.makedirs(os.path.dirname(path_name))
-            self.ob_mean, self.ob_std = random_agent_ob_mean_std(env, nsteps=10000)
+            self.ob_mean, self.ob_std = random_agent_ob_mean_std(env, nsteps=100) # 10000)
             np.save(
                 path_name + "/ob_mean.npy",
                 self.ob_mean,


### PR DESCRIPTION
I made a recent change to try to reduce how many times `update_auxiliary_task` is called, based on the comments you left on the code. 

Now there are 4 places in the code where `update_auxiliary_task` is being called :
- after collecting the rollout and before the reward is calculated
- in the ppo loss, it is called once, before the dynamic loss
- in the backprop loss, it is called twice - before the dynamic loss and before the backprop loss. The reason being that I'm considering there is a gradient step after the dynamic loss, which would change the model and affect the output of `update_auxiliary_task`

If the last statement is incorrect, and `update_auxiliary_task` needs to be called only once per step/epoch/batch, then we can move out of the loss functions back into the `learn` function and both the ppo loss and backprop loss would share that procedure. 

At some point we can look into the `update_auxiliary_task` as well to see if it can be further simplified. 

Edit: I changed the name of the function `ppo.update` to `ppo.learn` to make it clear that is where the gradient steps are happening. There are lots of update functions around the code, and I wanted to differentiate that is the only one that actually has a gradient update. Let me know if that is not ok. 