### PR TITLE
Visualizations

### DIFF
--- a/nupic/embodied/multitask/algorithms/custom_mtsac.py
+++ b/nupic/embodied/multitask/algorithms/custom_mtsac.py
@@ -269,7 +269,7 @@ class CustomMTSAC(MTSAC):
 
         return total_losses
 
-    def _evaluate_policy(self, epoch, policy_hook=None):
+    def _evaluate_policy(self, epoch, policy_hooks=[]):
         """Evaluate the performance of the policy via deterministic sampling.
 
             Statistics such as (average) discounted return and success rate are
@@ -285,9 +285,9 @@ class CustomMTSAC(MTSAC):
         """
         policy = self.get_updated_policy()
 
-        if policy_hook is not None:
-            hook = policy_hook(policy)
-            hook.attach()
+        for i in range(len(policy_hooks)):
+            policy_hooks[i] = policy_hooks[i](policy)
+            policy_hooks[i].attach()
 
         t0 = time()
         # Collect episodes for evaluation
@@ -306,10 +306,9 @@ class CustomMTSAC(MTSAC):
         )
         log_dict["average_return"] = np.mean(undiscounted_returns)
 
-        if policy_hook is not None:
-            ## return visualizations from hooks
-            visualizations = hook.get_visualizations()
-            log_dict['network_visualization'] = visualizations
+        for i in range(len(policy_hooks)):
+            name, visualization = policy_hooks[i].get_visualization()
+            log_dict[name] = visualization
 
         logging.warn(f"Time to evaluate policy: {time()-t0:.2f}")
 

--- a/nupic/embodied/multitask/modules/gaussian_mlp_module.py
+++ b/nupic/embodied/multitask/modules/gaussian_mlp_module.py
@@ -141,7 +141,7 @@ class GaussianMLPBaseModule(nn.Module):
         self._max_std = buffers["max_std"]
 
     @abc.abstractmethod
-    def _get_mean_and_log_std(self, *inputs):
+    def get_mean_log_std(self, *inputs):
         pass
 
     def forward(self, *inputs):
@@ -152,7 +152,7 @@ class GaussianMLPBaseModule(nn.Module):
             torch.distributions.independent.Independent: Independent
                 distribution.
         """
-        mean, log_std_uncentered = self._get_mean_and_log_std(*inputs)
+        mean, log_std_uncentered = self.get_mean_log_std(*inputs)
 
         log_std_uncentered = log_std_uncentered.clamp(min=self._min_std.item(),
                                                       max=self._max_std.item())
@@ -265,7 +265,7 @@ class GaussianTwoHeadedMLPModule(GaussianMLPBaseModule):
             learn_std=learn_std,
         )
 
-        self._shared_mean_log_std_network = MultiHeadedMLPModule(
+        self.mean_log_std = MultiHeadedMLPModule(
             n_heads=2,
             input_dim=input_dim,
             output_dims=output_dim,
@@ -282,7 +282,7 @@ class GaussianTwoHeadedMLPModule(GaussianMLPBaseModule):
             layer_normalization=layer_normalization
         )
 
-    def _get_mean_and_log_std(self, *inputs):
+    def get_mean_log_std(self, *inputs):
         """Get mean and std of Gaussian distribution given inputs.
         Args:
             *inputs: Input to the module.
@@ -290,7 +290,7 @@ class GaussianTwoHeadedMLPModule(GaussianMLPBaseModule):
             torch.Tensor: The mean of Gaussian distribution.
             torch.Tensor: The variance of Gaussian distribution.
         """
-        return self._shared_mean_log_std_network(*inputs)
+        return self.mean_log_std(*inputs)
 
 
 class GaussianTwoHeadedDendriticMLPModule(GaussianMLPBaseModule):
@@ -340,7 +340,7 @@ class GaussianTwoHeadedDendriticMLPModule(GaussianMLPBaseModule):
             learn_std=learn_std
         )
 
-        self._shared_mean_log_std_network = CustomDendriticMLP(
+        self.mean_log_std = CustomDendriticMLP(
             input_dim=input_dim,
             context_dim=context_dim,
             output_sizes=(output_dim, output_dim),
@@ -360,7 +360,7 @@ class GaussianTwoHeadedDendriticMLPModule(GaussianMLPBaseModule):
             preprocess_kw_percent_on=preprocess_kw_percent_on,
         )
 
-    def _get_mean_and_log_std(self, *inputs):
+    def get_mean_log_std(self, *inputs):
         """Get mean and std of Gaussian distribution given inputs.
         Args:
             
@@ -368,4 +368,4 @@ class GaussianTwoHeadedDendriticMLPModule(GaussianMLPBaseModule):
             torch.Tensor: The mean of Gaussian distribution.
             torch.Tensor: The variance of Gaussian distribution.
         """
-        return self._shared_mean_log_std_network(*inputs)
+        return self.mean_log_std(*inputs)

--- a/nupic/embodied/multitask/policies/gaussian_mlp_policy.py
+++ b/nupic/embodied/multitask/policies/gaussian_mlp_policy.py
@@ -101,7 +101,7 @@ class GaussianMLPPolicy(StochasticPolicy):
     ):
         super().__init__(env_spec, name="GaussianPolicy")
 
-        self._module = GaussianTwoHeadedMLPModule(
+        self.module = GaussianTwoHeadedMLPModule(
             input_dim=env_spec.observation_space.flat_dim,
             output_dim=env_spec.action_space.flat_dim,
             hidden_sizes=hidden_sizes,
@@ -130,7 +130,7 @@ class GaussianMLPPolicy(StochasticPolicy):
             torch.distributions.Distribution: Batch distribution of actions.
             dict[str, torch.Tensor]: Additional agent_info, as torch Tensors
         """
-        dist = self._module(observations)
+        dist = self.module(observations)
 
         return dist, dict(mean=dist.mean, log_std=(dist.variance.sqrt()).log())
 
@@ -225,7 +225,7 @@ class GaussianDendriticMLPPolicy(StochasticPolicy):
             self.context_dim = env_spec.observation_space.flat_dim
             self.context_func = get_mixed_data
 
-        self._module = GaussianTwoHeadedDendriticMLPModule(
+        self.module = GaussianTwoHeadedDendriticMLPModule(
             input_dim=self.input_dim,
             context_dim=self.context_dim,
             output_dim=env_spec.action_space.flat_dim,
@@ -265,6 +265,6 @@ class GaussianDendriticMLPPolicy(StochasticPolicy):
         obs_portion = self.input_func(observations=observations, num_tasks=self.num_tasks)
         context_portion = self.context_func(observations=observations, num_tasks=self.num_tasks)
 
-        dist = self._module(obs_portion, context_portion)
+        dist = self.module(obs_portion, context_portion)
 
         return dist, dict(mean=dist.mean, log_std=(dist.variance.sqrt()).log())

--- a/nupic/embodied/multitask/trainer.py
+++ b/nupic/embodied/multitask/trainer.py
@@ -37,6 +37,7 @@ from nupic.embodied.multitask.algorithms.custom_mtsac import CustomMTSAC
 from nupic.embodied.multitask.samplers.gpu_sampler import RaySampler
 from nupic.embodied.utils.garage_utils import create_policy_net, create_qf_net
 from nupic.embodied.utils.parser_utils import dict_to_namedtuple
+from nupic.embodied.utils.hooks import PolicyHook
 
 
 class Trainer():
@@ -259,7 +260,7 @@ class Trainer():
 
             # Run evaluation, with a given frequency
             if epoch % evaluation_frequency == 0:
-                eval_returns, eval_log_dict = self._algo._evaluate_policy(epoch)
+                eval_returns, eval_log_dict = self._algo._evaluate_policy(epoch, policy_hook=PolicyHook)
                 log_dict["average_return"] = np.mean(eval_returns)
                 log_dict.update(eval_log_dict)
 

--- a/nupic/embodied/multitask/trainer.py
+++ b/nupic/embodied/multitask/trainer.py
@@ -36,9 +36,10 @@ from garage.torch import set_gpu_mode
 from nupic.embodied.multitask.algorithms.custom_mtsac import CustomMTSAC
 from nupic.embodied.multitask.samplers.gpu_sampler import RaySampler
 from nupic.embodied.utils.garage_utils import create_policy_net, create_qf_net
-from nupic.embodied.utils.parser_utils import dict_to_namedtuple
-from nupic.embodied.utils.hooks import PolicyHook
 from nupic.embodied.utils.parser_utils import dict_to_dataclass
+
+from nupic.embodied.utils.hooks import HiddenActivationsPercentOnHook, AverageSegmentActivationsHook
+
 
 
 class Trainer():
@@ -261,7 +262,9 @@ class Trainer():
 
             # Run evaluation, with a given frequency
             if epoch % evaluation_frequency == 0:
-                eval_returns, eval_log_dict = self._algo._evaluate_policy(epoch, policy_hook=PolicyHook)
+                eval_returns, eval_log_dict = self._algo._evaluate_policy(
+                    epoch, policy_hooks=[HiddenActivationsPercentOnHook, AverageSegmentActivationsHook]
+                )
                 log_dict["average_return"] = np.mean(eval_returns)
                 log_dict.update(eval_log_dict)
 

--- a/nupic/embodied/utils/hooks.py
+++ b/nupic/embodied/utils/hooks.py
@@ -24,11 +24,14 @@ import torch
 import torch.nn as nn
 import abc
 from collections import defaultdict
+import numpy as np
+import matplotlib.colors as colors
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
 
-from nupic.research.frameworks.dendrites.metrics import plot_hidden_activations_by_unit
+from nupic.research.frameworks.dendrites import DendriticLayerBase
 
-
-class HookManager(metaclass=abc.ABCMeta):
+class PolicyVisualizationHook(metaclass=abc.ABCMeta):
     def __init__(self, net):
         self.net = net
     
@@ -36,8 +39,12 @@ class HookManager(metaclass=abc.ABCMeta):
     def attach(self):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def get_visualization(self):
+        raise NotImplementedError
 
-class PolicyHook(HookManager):
+
+class AverageSegmentActivationsHook(PolicyVisualizationHook):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -46,22 +53,165 @@ class PolicyHook(HookManager):
 
     def target_hook_fn(self, module, input, output):
         # input is (batch size x num_tasks) matrix
+        input = input[0]
 
         # verify preprocess only takes in one-hot encoded vector
         assert (input.count_nonzero(dim=1) == 1).all().item()
         
         # get one-hot encoded task id from each row
-        targets = (input == 1).nonzero(as_tuple=True)[0].squeeze()
+        targets = (input == 1).nonzero(as_tuple=True)[1].squeeze()
 
-        self.targets = torch.cat([self.targets, targets], dim=0)
+        self.targets = torch.cat([self.targets, targets], dim=0).to(torch.int)
+
+    def activation_hook_fn(self, module, input, output):
+        # output is (batch size x num_units x num_segments) matrix
+
+        self.activations = torch.cat([self.activations, output], dim=0)
+
+    def get_visualization(self, unit_to_plot=0):
+        """
+        Returns a heatmap of dendrite activations for a single unit, plotted using
+        matplotlib.
+        :param dendrite_activations: 3D torch tensor with shape (batch_size, num_units,
+                                    num_segments) in which entry b, i, j gives the
+                                    activation of the ith unit's jth dendrite segment for
+                                    example b
+        :param unit_to_plot: index of the unit for which to plot dendrite activations;
+                            plots activations of unit 0 by default
+        """
+
+        with torch.no_grad():
+            num_segments = self.activations.size(2)
+            num_tasks = self.targets.max().item() + 1
+            activations = self.activations[:, unit_to_plot, :]
+            
+            avg_activations = torch.zeros((num_segments, 0))
+
+            for t in range(num_tasks):
+                inds_t = torch.nonzero((self.targets == t).float()).squeeze()
+
+                activations_t = activations[inds_t, :].mean(dim=0).detach().cpu().unsqueeze(dim=1)
+
+                avg_activations = torch.cat((avg_activations, activations_t), dim=1)
+
+            vmax = avg_activations.abs().max().item()
+            vmin = -1.0 * vmax
+
+            ax = plt.gca()
+
+            ax.imshow(avg_activations.detach().cpu().numpy(), cmap="coolwarm_r", vmin=vmin, vmax=vmax)
+            plt.colorbar(
+                cm.ScalarMappable(norm=colors.Normalize(-1, 1), cmap="coolwarm_r"), ax=ax, location="left",
+                shrink=0.6, drawedges=False, ticks=[-1.0, 0.0, 1.0]
+            )
+
+            ax.set_xlabel("Task")
+            ax.set_ylabel("Segment")
+            ax.set_xticks(range(num_tasks))
+            ax.set_yticks(range(num_segments))
+
+            plt.tight_layout()
+            figure = plt.gcf()
+
+            return "average_segment_activations", figure
+
+        
+    def attach(self):
+        preprocess_layers = []
+        dendrite_layers = []
+
+        for name, layer in self.net.named_modules():
+            if isinstance(layer, nn.Sequential) and "preprocess" in name:
+                preprocess_layers.append(layer)
+            elif isinstance(layer, DendriticLayerBase):
+                dendrite_layers.append(layer.segments)
+            
+
+        # only 1 preprocess and 1 dendrite layer
+        assert len(preprocess_layers) == 1
+        assert len(dendrite_layers) == 1
+
+        preprocess_layers[0].register_forward_hook(self.target_hook_fn)
+        dendrite_layers[0].register_forward_hook(self.activation_hook_fn)
+
+
+class HiddenActivationsPercentOnHook(PolicyVisualizationHook):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.targets = torch.Tensor([])
+        self.activations = torch.Tensor([])
+
+    def target_hook_fn(self, module, input, output):
+        # input is (batch size x num_tasks) matrix
+        input = input[0]
+
+        # verify preprocess only takes in one-hot encoded vector
+        assert (input.count_nonzero(dim=1) == 1).all().item()
+        
+        # get one-hot encoded task id from each row
+        targets = (input == 1).nonzero(as_tuple=True)[1].squeeze()
+
+        self.targets = torch.cat([self.targets, targets], dim=0).to(torch.int)
 
     def activation_hook_fn(self, module, input, output):
         # input/output is (batch size x hidden dim) matrix
 
         self.activations = torch.cat([self.activations, output], dim=0)
 
-    def get_visualization(self):
-        return plot_hidden_activations_by_unit(self.activations, self.targets)
+    def get_visualization(self, num_units_to_plot=64):
+        """
+        Returns a heatmap with shape (num_categories, num_units) where cell c, i gives the
+        mean value of hidden activations for unit i over all given examples from category
+        c.
+        :param activations: 2D torch tensor with shape (batch_size, num_units) where entry
+                            b, i gives the activation of unit i for example b
+        :param targets: 1D torch tensor with shape (batch_size,) where entry b gives the
+                        target label for example b
+        :param num_units_to_plot: an integer which gives how many columns to show, for ease
+                                of visualization; only the first num_units_to_plot units
+                                are shown
+        """
+
+        with torch.no_grad():
+            device = self.activations.device
+
+            num_tasks = self.targets.max().item() + 1
+            _, num_units = self.activations.size()
+
+            #habu = hidden activations by unit
+            habu = torch.zeros((0, num_units))
+            habu = habu.to(device)
+
+            for t in range(num_tasks):
+                inds_t = torch.nonzero((self.targets == t).float(), as_tuple=True)
+
+                habu_t = self.activations[inds_t]
+
+                habu_t = habu_t.mean(dim=0).unsqueeze(dim=0)
+                habu = torch.cat((habu, habu_t))
+
+            habu = habu[:, :num_units_to_plot].detach().cpu().numpy()
+
+            max_val = np.abs(habu).max()
+
+            ax = plt.gca()
+
+            ax.imshow(habu, cmap="Greens", vmin=0, vmax=max_val)
+            plt.colorbar(
+                cm.ScalarMappable(cmap="Greens"), ax=ax, location="top",
+                shrink=0.5, ticks=[0.0, 0.5, 1.0], drawedges=False
+            )
+
+            ax.set_aspect(2.5)
+            ax.set_xlabel("Hidden unit")
+            ax.set_ylabel("Task")
+            ax.get_yaxis().set_ticks(range(num_tasks))
+            
+            plt.tight_layout()
+            figure = plt.gcf()
+
+            return "hidden_activations_percent_on", figure
         
     def attach(self):
         preprocess_layers = []
@@ -78,6 +228,4 @@ class PolicyHook(HookManager):
         assert len(dendrite_layers) == 1
 
         preprocess_layers[0].register_forward_hook(self.target_hook_fn)
-        dendrite_layers[0].register_forward_hook(self.activation_hook_fn)
-
-        
+        dendrite_layers[0].register_forward_hook(self.activation_hook_fn)        

--- a/nupic/embodied/utils/hooks.py
+++ b/nupic/embodied/utils/hooks.py
@@ -1,0 +1,83 @@
+# ------------------------------------------------------------------------------
+#  Numenta Platform for Intelligent Computing (NuPIC)
+#  Copyright (C) 2021, Numenta, Inc.  Unless you have an agreement
+#  with Numenta, Inc., for a separate license for this software code, the
+#  following terms and conditions apply:
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero Public License version 3 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Affero Public License for more details.
+#
+#  You should have received a copy of the GNU Affero Public License
+#  along with this program.  If not, see http://www.gnu.org/licenses.
+#
+#  http://numenta.org/licenses/
+#
+# ------------------------------------------------------------------------------
+
+import torch
+import torch.nn as nn
+import abc
+from collections import defaultdict
+
+from nupic.research.frameworks.dendrites.metrics import plot_hidden_activations_by_unit
+
+
+class HookManager(metaclass=abc.ABCMeta):
+    def __init__(self, net):
+        self.net = net
+    
+    @abc.abstractmethod
+    def attach(self):
+        raise NotImplementedError
+
+
+class PolicyHook(HookManager):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.targets = torch.Tensor([])
+        self.activations = torch.Tensor([])
+
+    def target_hook_fn(self, module, input, output):
+        # input is (batch size x num_tasks) matrix
+
+        # verify preprocess only takes in one-hot encoded vector
+        assert (input.count_nonzero(dim=1) == 1).all().item()
+        
+        # get one-hot encoded task id from each row
+        targets = (input == 1).nonzero(as_tuple=True)[0].squeeze()
+
+        self.targets = torch.cat([self.targets, targets], dim=0)
+
+    def activation_hook_fn(self, module, input, output):
+        # input/output is (batch size x hidden dim) matrix
+
+        self.activations = torch.cat([self.activations, output], dim=0)
+
+    def get_visualization(self):
+        return plot_hidden_activations_by_unit(self.activations, self.targets)
+        
+    def attach(self):
+        preprocess_layers = []
+        dendrite_layers = []
+
+        for name, layer in self.net.named_modules():
+            if isinstance(layer, nn.Sequential) and "preprocess" in name:
+                preprocess_layers.append(layer)
+            elif isinstance(layer, nn.Sequential) and "dendrite" in name:
+                dendrite_layers.append(layer)
+
+        # only 1 preprocess and 1 dendrite layer
+        assert len(preprocess_layers) == 1
+        assert len(dendrite_layers) == 1
+
+        preprocess_layers[0].register_forward_hook(self.target_hook_fn)
+        dendrite_layers[0].register_forward_hook(self.activation_hook_fn)
+
+        

--- a/projects/multitask/args_parser.py
+++ b/projects/multitask/args_parser.py
@@ -209,13 +209,14 @@ def create_cmd_parser():
         "-c",
         "--cpu",
         action="store_true",
-        default="False",
+        default=False,
         help="Whether to use CPU even if GPU is available",
     )
     parser.add_argument(
         "-r",
         "--restore",
         action="store_true",
+        default=False,
         help="Whether to restore from existing experiment with same project name",
     )
     parser.add_argument(

--- a/projects/multitask/experiments/base.py
+++ b/projects/multitask/experiments/base.py
@@ -28,11 +28,10 @@ base = dict()
 
 debug = deepcopy(base)
 debug = dict(
-    evaluation_frequency=10,
+    evaluation_frequency=1,
     timesteps=100000,
     buffer_batch_size=32,
     num_grad_steps_scale=0.01,  # 5 steps,
-    project_id="shqr401",
 )
 
 singleseg_mt10_base = dict(

--- a/projects/multitask/experiments/multiseg_experiments.py
+++ b/projects/multitask/experiments/multiseg_experiments.py
@@ -239,6 +239,8 @@ no_overlap_10d_abs_max_signed.update(
     fp16=True,
     preprocess_output_dim=10,
     dendritic_layer_class="abs_max_gating_signed",
+    wandb_group="MT10: Paper Figures",
+    evaluation_frequency=5,
 )
 
 

--- a/projects/multitask/run.py
+++ b/projects/multitask/run.py
@@ -82,9 +82,7 @@ if __name__ == "__main__":
     if run_args.wandb_run_name != "":
         run_args.wandb_run_name = run_args.exp_name
 
-    # Restore last known experiment
-    print(run_args.restore, run_args.project_id, trainer_args.project_id)
-    # Restore andd override project id from config with project id from cmd parser
+    # Restore last known experiment and override project id from config with project id from cmd parser
     if run_args.restore:
         if not run_args.project_id:
             trainer_args.project_id = find_latest_run(


### PR DESCRIPTION
Added visualizations in `hooks.py`, which use forward hooks to gather and display visualizations during network evaluation

Visualizations are saved to wandb by default